### PR TITLE
Changed 3D detected node z position

### DIFF
--- a/yolov8_bringup/launch/yolov8_3d.launch.py
+++ b/yolov8_bringup/launch/yolov8_3d.launch.py
@@ -134,7 +134,7 @@ def generate_launch_description():
             "device": device,
             "enable": enable,
             "threshold": threshold,
-            "image_reliability": image_reliability,
+            "image_reliability": image_reliability
         }],
         remappings=[("image_raw", input_image_topic)]
     )
@@ -167,7 +167,7 @@ def generate_launch_description():
             ("image_raw", input_image_topic),
             ("depth_image", input_depth_topic),
             ("depth_info", input_depth_info_topic),
-            ("detections", "tracking")
+            # ("detections", "tracking")
         ]
     )
 

--- a/yolov8_bringup/launch/yolov8_3d.launch.py
+++ b/yolov8_bringup/launch/yolov8_3d.launch.py
@@ -167,7 +167,7 @@ def generate_launch_description():
             ("image_raw", input_image_topic),
             ("depth_image", input_depth_topic),
             ("depth_info", input_depth_info_topic),
-            # ("detections", "tracking")
+            ("detections", "tracking")
         ]
     )
 

--- a/yolov8_ros/yolov8_ros/detect_3d_node.py
+++ b/yolov8_ros/yolov8_ros/detect_3d_node.py
@@ -220,6 +220,7 @@ class Detect3DNode(CascadeLifecycleNode):
 
         roi = depth_image[v_min:v_max, u_min:u_max] / \
             self.depth_image_units_divisor  # convert to meters
+        
         if not np.any(roi):
             return None
 
@@ -285,41 +286,35 @@ class Detect3DNode(CascadeLifecycleNode):
 
             center_x = (up.point.x + down.point.x) / 2
             center_y = (up.point.y + down.point.y) / 2
-
-        bb_center_z_coord = depth_image[int(center_y)][int(
-            center_x)] / self.depth_image_units_divisor
-
-        # if the center of the BB is not detected
-        if np.isnan(bb_center_z_coord) or \
-                bb_center_z_coord == 0 or \
-                np.isinf(bb_center_z_coord):
+        
+        roi = np.ma.masked_invalid(roi)
+        if np.any(np.isfinite(roi)) and np.any(roi != 0):
+            average_z_coord = np.mean(roi[roi>0])
+        else:
             return None
 
         # if the center of the BB is detected
-        z_diff = np.abs(roi - bb_center_z_coord)
+        z_diff = np.abs(roi - average_z_coord)
         mask_z = z_diff <= self.maximum_detection_threshold
         if not np.any(mask_z):
             return None
 
         roi_threshold = roi[mask_z]
         z_min, z_max = np.min(roi_threshold), np.max(roi_threshold)
-        z = (z_max + z_min) / 2
-        if z == 0:
-            return None
 
         # project from image to world space
         k = depth_info.k
         px, py, fx, fy = k[2], k[5], k[0], k[4]
-        x = z * (center_x - px) / fx
-        y = z * (center_y - py) / fy
-        w = z * (size_x / fx)
-        h = z * (size_y / fy)
+        x = average_z_coord * (center_x - px) / fx
+        y = average_z_coord * (center_y - py) / fy
+        w = average_z_coord * (size_x / fx)
+        h = average_z_coord * (size_y / fy)
 
         # create 3D BB
         msg = BoundingBox3D()
         msg.center.position.x = x
         msg.center.position.y = y
-        msg.center.position.z = z
+        msg.center.position.z = average_z_coord
         msg.size.x = w
         msg.size.y = h
         msg.size.z = float(z_max - z_min)


### PR DESCRIPTION
In the `detect_3d_node` in the `convert_bb_to_3d` function I modified the calculation of the object's z-position.

The z is not calculated as the depth value at the center of the bounding box, but as the mean depth value corresponding to the object's roi (excluding invalid values such as 0, inf, nan from the calculation). 
This avoids discarding the object's detection just because of a hole in the depth, but attempts to retrieve it anyway. 

In addition, I commented out the remapping` ('detections', 'tracking') `for the `yolov8_detect_3d_node` in the `yolov8_3d.launch.py 
 `which causes a discarding of the detections depending on the tracker configuration.