### PR TITLE
Will be the last PR about convert_bb_to_3d?

### DIFF
--- a/yolov8_ros/yolov8_ros/detect_3d_node.py
+++ b/yolov8_ros/yolov8_ros/detect_3d_node.py
@@ -206,7 +206,6 @@ class Detect3DNode(CascadeLifecycleNode):
         depth_info: CameraInfo,
         detection: Detection
     ) -> BoundingBox3D:
-        self.get_logger().info(f'Converting BB to 3D...')
 
         # crop depth image by the 2d BB
         center_x = int(detection.bbox.center.position.x)
@@ -222,7 +221,7 @@ class Detect3DNode(CascadeLifecycleNode):
         roi = depth_image[v_min:v_max, u_min:u_max] / \
             self.depth_image_units_divisor  # convert to meters
         
-        # if the center of the BB is detected
+        # check if there is valid information in the ROI
         roi = np.ma.masked_invalid(roi)
         if np.any(np.isfinite(roi)) and np.any(roi != 0):
             average_z_coord = np.mean(roi[roi>0])
@@ -299,7 +298,6 @@ class Detect3DNode(CascadeLifecycleNode):
 
         if center_x < 0 or center_x >= depth_image.shape[1] or \
                 center_y < 0 or center_y >= depth_image.shape[0]:
-            self.get_logger().info(f'Center is out of the image limits')
             return None
         
         z_diff = np.abs(roi - average_z_coord)

--- a/yolov8_ros/yolov8_ros/detect_3d_node.py
+++ b/yolov8_ros/yolov8_ros/detect_3d_node.py
@@ -293,13 +293,9 @@ class Detect3DNode(CascadeLifecycleNode):
         
 
         # check center_x and center_y inside the image limits
-        center_x = int(center_x)
-        center_y = int(center_y)
-
-        if center_x < 0 or center_x >= depth_image.shape[1] or \
-                center_y < 0 or center_y >= depth_image.shape[0]:
-            return None
-        
+        center_x = min(max(0, int(center_x)), depth_image.shape[1] - 1)
+        center_y = min(max(0, int(center_y)), depth_image.shape[0] - 1)
+                
         z_diff = np.abs(roi - average_z_coord)
         mask_z = z_diff <= self.maximum_detection_threshold
          


### PR DESCRIPTION
Previously the centre in z of the detected object was only `dept[v,u]`, but we switched to creating a filtered roi that only holds valid info (no `inf/nan`). There were None returns related to the desire to keep part of the old implementation that discarded the acquisition. Final solution:
- `None` info if there is no valid info in the filtered roi (or all values are `= 0`). As the value of z is averaged over all the filtered roi that have non-zero values. And thus `dept[v,u]` is no longer used, as the individual point may be noisy or may have invalid info.
- I clamp the centre of the detected object inside the shape of image, if the centre is partially out of the shape, not discarded.
